### PR TITLE
add Custom-config

### DIFF
--- a/app/Handle.php
+++ b/app/Handle.php
@@ -2,6 +2,7 @@
 namespace App;
 
 use App\Utils\Queue;
+use App\Utils\Redis;
 
 class Handle
 {
@@ -26,15 +27,15 @@ class Handle
             return self::response(400, [], 'Param delay_time error!');
         }
 
-        if ( !isset($this->data['list_name']) || !$this->data['list_name'] ) {
-            return self::response(400, [], 'Param list_name error!');
-        }
-
         $information = [
             'delay_time' => intval($this->data['delay_time']),
-            'list_name'  => $this->data['list_name'],
-            'hide_time'  => isset($this->data['hide_time']) ? (intval($this->data['hide_time']) > 30 ? intval($this->data['hide_time']) : 30) : 30
+            'hide_time'  => isset($this->data['hide_time']) ? max(intval($this->data['hide_time']), 30) : 30
         ];
+
+        if (isset($this->data['config']) && !empty($this->data['config']) && isset($this->data['list_name'])) {
+            $information['list_name'] = $this->data['list_name'];
+            $information['config'] = $this->data['config'];
+        }
 
         if (Queue::getDefaultInstance()->hsetnx(Queue::queueInfoName(), $this->queue_name, json_encode($information, JSON_UNESCAPED_UNICODE))) {
             Queue::getDefaultInstance()->rpush(Queue::queueListName(), $this->queue_name);
@@ -107,6 +108,11 @@ class Handle
     public function getMessage()
     {
         $info = $this->getQueueInfo();
+
+        if( isset($info['config']['host']) ) {
+            $message = Redis::instance('', $info['config'])->lpop($info['list_name']);
+            return self::response(200, ['messageId'=>'custom-active-queue', 'content'=>$message]);
+        }
 
         $messageId = Queue::getActiveInstance()->lpop(Queue::activeName($this->queue_name));
         if (! $messageId ) {

--- a/app/Handle.php
+++ b/app/Handle.php
@@ -111,6 +111,7 @@ class Handle
 
         if( isset($info['config']['host']) ) {
             $message = Redis::instance('', $info['config'])->lpop($info['list_name']);
+            Redis::close('', $info['config']);
             return self::response(200, ['messageId'=>'custom-active-queue', 'content'=>$message]);
         }
 

--- a/app/Process.php
+++ b/app/Process.php
@@ -62,6 +62,7 @@ class Process
                     $activeInstance->rpush($info['list_name'], $message);
                 }
             }
+            Redis::close('', $info['config']);
         } else {
             foreach ($delays as $messageId) {
                 if (Queue::getDefaultInstance()->hexists(Queue::messageName($name), $messageId)) {


### PR DESCRIPTION
- 增加可自定义活跃消息队列的配置，兼容[delay-server-single](https://github.com/ruesin/delay-server-single)
- Process从queue_list弹出队列后，处理期间发生致命错误时，返还回去，保证队列完整。
- 自定义队列使用完成后关闭连接。